### PR TITLE
Update picalc-pipeline-run.yaml

### DIFF
--- a/tekton/run/picalc-pipeline-run.yaml
+++ b/tekton/run/picalc-pipeline-run.yaml
@@ -7,7 +7,7 @@ spec:
     name: build-and-deploy-pipeline
   params:
     - name: gitUrl
-      value: https://github.com/odrodrig/tekton-tutorial.git
+      value: https://github.com/IBM/tekton-tutorial-openshift
     - name: gitRevision
       value: beta-update
     - name: pathToYamlFile


### PR DESCRIPTION
Hi! @odrodrig 
I was attempting the tutorial and noticed that the provided git repo in this file doesn't exist anymore (if you take a look at the repo, you will notice there have been changes in the directory and files) so I changed the URL in the yaml file.
I would also recommend updating the tutorial documentation in this section https://ibm.github.io/tekton-tutorial-openshift/#8-create-a-pipelinerun + the hyperlink of the text "**tekton/run/picalc-pipeline-run.yaml**." is leading to the PVC file, not the pipeline run file.